### PR TITLE
progbar updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ members = ["zung_mini"]
 resolver = "2"
 
 [dependencies]
+zung_mini = "0.1.2"
 anstyle = "1.0.8"
 clap = { version = "4.5.18", features = ["derive"] }
-
-zung_mini = { version = "0.1.2", path = "./zung_mini" }


### PR DESCRIPTION
- **chore: Release**
- **fix: using the published crate instead**
